### PR TITLE
Updated to use @ notation for implicit user

### DIFF
--- a/open-world/middleware/src/endpoints/write.ts
+++ b/open-world/middleware/src/endpoints/write.ts
@@ -29,8 +29,7 @@ async function submitMoves(x: number, y: number): Promise<OldResult> {
   const userWalletAddress = query.result;
 
   const conciseBuilder = builder.initialize();
-  conciseBuilder.setPrefix('m'); // m|*user|x|y
-  conciseBuilder.addValue({ value: userWalletAddress, isStateIdentifier: true });
+  conciseBuilder.setPrefix('m', true); // @m||x|y
   conciseBuilder.addValue({ value: String(x) });
   conciseBuilder.addValue({ value: String(y) });
 

--- a/open-world/state-transition/src/stf/v1/parser.ts
+++ b/open-world/state-transition/src/stf/v1/parser.ts
@@ -3,7 +3,7 @@ import type { ParsedSubmittedInput } from './types';
 
 const myGrammar = `
         joinWorld       = j|
-        submitMove      = m|*user|x|y
+        submitMove      = @m||x|y
         submitIncrement = i|*x|*y
 `;
 


### PR DESCRIPTION
Updated command

`m|*user|a|b`

to 

`@m|a|b`