### PR TITLE
Fix middleware types

### DIFF
--- a/chess/middleware/scripts/build.sh
+++ b/chess/middleware/scripts/build.sh
@@ -4,4 +4,6 @@ cd middleware
 
 DOTENV_CONFIG_PATH=../../.env.$NODE_ENV npx -c ../node_modules/paima-sdk/node_modules/.bin/paima-build-middleware
 
-cp packaged/middleware.js ../frontend/src/paima/middleware.js
+cp packaged/middleware.js $OUT/middleware.js
+rsync -ar --include='*/' --include='*.d.ts' --exclude='*' build/ $OUT/
+mv $OUT/index.d.ts $OUT/middleware.d.ts


### PR DESCRIPTION
The types for the middleware were broken without anybody realizing because the `esbuild-plugin-d.ts` setup was broken (and even removed entirely in https://github.com/PaimaStudios/paima-engine/pull/223)

This PR should fix it for now