### PR TITLE
add avail setup/template for chess

### DIFF
--- a/chess/.env.avail-localhost
+++ b/chess/.env.avail-localhost
@@ -1,0 +1,57 @@
+START_BLOCKHEIGHT="1"
+
+SELF_SIGNING_ENABLED="true"
+SELF_SIGNING_API_KEY="XX"
+
+## Middleware
+# Note: This is the URL which your middleware will use to interact with your game node webserver
+# Example: "http://localhost:3333"
+BACKEND_URI="http://localhost:3333"
+
+## MISC
+# Note: This is the port your game node webserver will use
+# Example: "3333"
+WEBSERVER_PORT="3333"
+# Note: This enables running your game node with just the webserver running, meaning no new blocks will be synced.
+# This is primarily useful for development, devops, or testing other edge cases where you want to interact with
+# the game node but not have the game state progress forward.
+SERVER_ONLY_MODE="false"
+
+## DATABASE
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_NAME="postgres"
+DB_USER="postgres"
+DB_PW="postgres"
+
+## Batcher setup
+# BATCHER DB connection:
+BATCHER_DB_HOST="localhost"
+BATCHER_DB_PORT="54321"
+BATCHER_DB_NAME="postgres"
+BATCHER_DB_USER="postgres"
+BATCHER_DB_PW="postgres"
+
+# Batcher Contract:
+DEFAULT_FEE="10000000000000000"
+
+# Batcher Webserver:
+BATCHER_PORT="3340"
+
+BATCHER_URI="http://localhost:3340"
+
+# Batcher Validation parameters:
+GAME_NODE_URI="http://localhost:3333"
+DEFAULT_VALIDATION_ACTIVE="false"
+GAME_INPUT_VALIDATOR_PERIOD="1000"
+BATCHED_TRANSACTION_POSTER_PERIOD="3000"
+BATCHED_MESSAGE_SIZE_LIMIT="100000"
+MAX_USER_INPUTS_PER_MINUTE="10"
+MAX_USER_INPUTS_PER_DAY="500"
+
+# Batcher Avail settings
+BATCHER_NETWORK='avail'
+BATCHER_PRIVATE_KEY='bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice'
+BATCHER_AVAIL_LIGHT_CLIENT="http://localhost:7007"
+CHAIN_URI="ws://127.0.0.1:9944"
+SECURITY_NAMESPACE="sp1"

--- a/chess/avail/Dockerfile
+++ b/chess/avail/Dockerfile
@@ -1,0 +1,46 @@
+FROM rust:1.75 AS base
+
+RUN apt update -y && apt install protobuf-compiler -y
+
+FROM base AS node_builder
+
+RUN git clone https://github.com/availproject/avail
+WORKDIR "/avail"
+
+# This builds the binary. Important to note here is the fast-runtime feature to have 8 seconds between blocks.
+RUN cargo build --locked --release --features fast-runtime
+RUN cp target/release/avail-node /bin/
+RUN which curl
+
+FROM debian:bookworm-slim AS node
+COPY --from=node_builder /bin/avail-node /bin
+ADD ./health_check.sh bin
+RUN apt update -y && apt install curl net-tools vim -y
+CMD ["/bin/avail-node", "--dev", "--name=LocalAvailNode", "-d=/output/data", "--rpc-methods=unsafe", "--unsafe-rpc-external", "--rpc-cors=all", "--enable-kate-rpc", "--state-pruning=archive-canonical"]
+
+## light client
+
+FROM rust:1.75 AS light_builder
+
+RUN apt update -y && apt install clang -y
+
+RUN git clone https://github.com/availproject/avail-light.git
+WORKDIR "/avail-light"
+
+RUN cargo build --locked --release --bin avail-light
+RUN cp target/release/avail-light /bin/
+
+RUN cargo build --locked --release -p avail-light-bootstrap
+RUN cp target/release/avail-light-bootstrap /bin/
+
+FROM debian:bookworm-slim AS light
+COPY --from=light_builder /bin/avail-light /bin
+
+ADD ./avail-light-config.yaml .
+ADD ./identity.toml .
+
+CMD ["/bin/avail-light", "--config", "avail-light-config.yaml"]
+
+FROM debian:bookworm-slim AS bootstrap
+COPY --from=light_builder /bin/avail-light-bootstrap /bin
+CMD ["/bin/avail-light-bootstrap"]

--- a/chess/avail/avail-light-config.yaml
+++ b/chess/avail/avail-light-config.yaml
@@ -1,0 +1,14 @@
+log_level = "info"
+http_server_host = "0.0.0.0"
+http_server_port = 7007
+
+secret_key = { seed = "avail" }
+port = 37000
+
+full_node_ws = ["ws://node:9944"]
+app_id = 1
+confidence = 92.0
+block_processing_delay = 0
+sync_start_block = 0
+
+bootstraps = ["/dns4/lightbootstrap/tcp/39000/p2p/12D3KooWStAKPADXqJ7cngPYXd2mSANpdgh1xQ34aouufHA2xShz"]

--- a/chess/avail/compose.yml
+++ b/chess/avail/compose.yml
@@ -1,0 +1,35 @@
+services:
+  node:
+    build:
+      dockerfile: Dockerfile
+      target: node
+    ports:
+      - 30333:30333
+      - "9944:9944"
+      - "9933:9933"
+    healthcheck:
+      test: ["CMD", "sh", "/bin/health_check.sh"]
+      interval: 2s
+      timeout: 60s
+      retries: 30
+
+  lightbootstrap:
+    build:
+      dockerfile: Dockerfile
+      target: bootstrap
+    ports:
+      - "7700:7700"
+      - "39000:39000"
+
+  light:
+    build:
+      dockerfile: Dockerfile
+      target: light
+    depends_on:
+      node:
+        condition: service_healthy
+      lightbootstrap:
+        condition: service_started
+    ports:
+      - "7007:7007"
+    restart: on-failure:5 

--- a/chess/avail/health_check.sh
+++ b/chess/avail/health_check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+curl -X POST \
+     -H 'Content-Type: application/json' \
+     -d '{"jsonrpc":"2.0","id":"1","method":"system_health","params":[]}' \
+     http://localhost:9944 || exit 1

--- a/chess/avail/identity.toml
+++ b/chess/avail/identity.toml
@@ -1,0 +1,1 @@
+avail_secret_uri = 'bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice'

--- a/chess/config.avail-localhost.yml
+++ b/chess/config.avail-localhost.yml
@@ -1,0 +1,7 @@
+avail-main:
+  type: avail-main
+  lightClient: 'http://localhost:7007'
+  rpc: ws://127.0.0.1:9944
+  delay: 0
+  confirmationDepth: 0
+  genesisHash: "0xdd60847daa1119ecc9bdd006b140087737ac03d260ce110ecd7cb33cf721be35"


### PR DESCRIPTION
I'm not really sure what to do with this exactly, so for now this is mostly just an example of the setup.

The options I see:

1. We somehow enable using the avail base funnel in some of the existing templates (like this does with chess, but some extra things are needed).
2. We set an entire new template. In that case I'm not sure what should be the contents. Some simple page to be able to submit some inputs?

And then there is the case of the parallel funnel, the example configuration here is only for the base funnel, since it's what I've been using to test the batcher (with chess). Not sure if we should have an example of evm + avail too (and which one).

I should mention that with the latest batcher this doesn't work anymore. Submissions go through, but the frontend always times out before that. I think this is because now the batcher waits for finalization, instead of only inclusion. That said, this may be just an issue of the template not handling the mqtt events yet.

How to use this:

1. Copy `config.avail-localhost.yml` and `env.avail-localhost` to the root directory.
2. Rename those to `config.localhost.yml` and `.env.localhost`. Or set NETWORK=avail-localhost.
3. Run `npm run chain:start:avail` inside chess.

This will take awhile the first time, since the node is built from source. The reason for this is that I wanted to be able to have the `fast-runtime` feature for faster blocks, since it's much more nicer to test. I think this is probably fine since then the container can be re-used.

The network is temporary, there are no volumes (like it works right now with hardhat).

4. Run the engine.
5. Run the batcher.