### PR TITLE
add events dummy example to chess

### DIFF
--- a/chess/.env.example
+++ b/chess/.env.example
@@ -74,3 +74,5 @@ MAX_USER_INPUTS_PER_DAY="500"
 
 # Batcher wallet
 BATCHER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # hardhat local node key
+
+MQTT_BROKER=true

--- a/chess/esbuildconfig.cjs
+++ b/chess/esbuildconfig.cjs
@@ -5,8 +5,11 @@ const {
 
 const { config, outFiles, workspace } = generateConfig(
   "api",
-  "state-transition"
+  "state-transition",
+  "precompiles",
+  "events",
 );
+
 esbuild.build(config);
 
 console.log(

--- a/chess/events/package.json
+++ b/chess/events/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@chess/events",
+  "version": "1.0.0",
+  "description": "Events for Chess game, to be imported into any frontend",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
+    "lint": "prettier --write '**/*.ts'"
+  },
+  "keywords": [],
+  "author": "PaimaStudios",
+  "dependencies": {
+    "esrun": "^3.2.26",
+    "mqtt": "5.8.1",
+    "@sinclair/typebox": "0.33.4"
+  }
+}

--- a/chess/events/src/index.ts
+++ b/chess/events/src/index.ts
@@ -1,0 +1,84 @@
+import type { EventQueue } from '@paima/events';
+import { generateAppEvents } from '@paima/events';
+import { genEvent } from '@paima/events';
+import { Type } from '@sinclair/typebox';
+
+export const CreatedLobby_v1 = genEvent({
+  name: 'CreatedLobby',
+  fields: [
+    {
+      indexed: true,
+      name: 'user',
+      type: Type.String(),
+    },
+    {
+      indexed: true,
+      name: 'lobbyId',
+      type: Type.String(),
+    },
+    {
+      indexed: false,
+      name: 'rounds',
+      type: Type.Number(),
+    },
+  ],
+} as const);
+
+export const CreatedLobby_v2 = genEvent({
+  name: 'CreatedLobby',
+  fields: [
+    {
+      indexed: true,
+      name: 'user',
+      type: Type.String(),
+    },
+    {
+      indexed: true,
+      name: 'lobbyId',
+      type: Type.String(),
+    },
+    {
+      indexed: false,
+      name: 'rounds',
+      type: Type.Number(),
+    },
+    {
+      indexed: false,
+      name: 'isPractice',
+      type: Type.Boolean(),
+    },
+  ],
+});
+
+export const JoinedLobby = genEvent({
+  name: 'JoinedLobby',
+  fields: [
+    {
+      indexed: true,
+      name: 'lobbyId',
+      type: Type.String(),
+    },
+    {
+      indexed: false,
+      name: 'player',
+      type: Type.String(),
+    },
+  ],
+});
+
+export const MatchWon = genEvent({
+  name: 'MatchWon',
+  fields: [
+    {
+      indexed: true,
+      name: 'winner',
+      type: Type.String(),
+    },
+  ],
+});
+
+const eventDefinitions = [CreatedLobby_v1, CreatedLobby_v2, JoinedLobby, MatchWon] as const;
+
+export const events = generateAppEvents(eventDefinitions);
+
+export type Events = EventQueue<typeof eventDefinitions>;

--- a/chess/events/tsconfig.json
+++ b/chess/events/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "include": ["src/**/*"]
+}

--- a/chess/precompiles/package.json
+++ b/chess/precompiles/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@chess/precompiles",
+  "version": "1.0.0",
+  "description": "Module which includes all precompiles",
+  "main": "build/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
+    "dev": "DOTENV_CONFIG_PATH=../.env.localhost node --require dotenv/config --experimental-specifier-resolution=node build/index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  },
+  "devDependencies": {
+  }
+}

--- a/chess/precompiles/src/index.ts
+++ b/chess/precompiles/src/index.ts
@@ -1,0 +1,7 @@
+import { generatePrecompiles } from '@paima/precompiles';
+
+export enum PrecompileNames {
+  Default = 'default',
+}
+
+export const precompiles = generatePrecompiles(PrecompileNames);

--- a/chess/precompiles/tsconfig.json
+++ b/chess/precompiles/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../utils" }, { "path": "../db" }, { "path": "../events"}]
+}

--- a/chess/scripts/pack.sh
+++ b/chess/scripts/pack.sh
@@ -4,6 +4,8 @@ npm run build
 
 BUNDLE_WORKSPACE=api node ./esbuildconfig.cjs
 BUNDLE_WORKSPACE=state-transition node ./esbuildconfig.cjs
+BUNDLE_WORKSPACE=precompiles node ./esbuildconfig.cjs
+BUNDLE_WORKSPACE=events node ./esbuildconfig.cjs
 
 cp api/src/tsoa/swagger.json ./packaged/openapi.json
 

--- a/chess/state-transition/package.json
+++ b/chess/state-transition/package.json
@@ -17,7 +17,8 @@
     "chess.js": "^1.0.0-beta.3",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "@paima/events": "*"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/chess/state-transition/src/stf/v1/persist/practice.ts
+++ b/chess/state-transition/src/stf/v1/persist/practice.ts
@@ -1,5 +1,6 @@
 import type { SQLUpdate } from '@paima/node-sdk/db';
 import { createScheduledData } from '@paima/node-sdk/db';
+import { PrecompileNames } from '@chess/precompiles';
 
 // Schedule a practice move update to be executed in the future
 export function schedulePracticeMove(
@@ -7,7 +8,11 @@ export function schedulePracticeMove(
   round: number,
   block_height: number
 ): SQLUpdate {
-  return createScheduledData(createPracticeInput(lobbyId, round), block_height);
+  return createScheduledData(
+    createPracticeInput(lobbyId, round),
+    block_height,
+    PrecompileNames.Default
+  );
 }
 
 function createPracticeInput(lobbyId: string, round: number) {

--- a/chess/state-transition/src/stf/v1/persist/stats.ts
+++ b/chess/state-transition/src/stf/v1/persist/stats.ts
@@ -5,6 +5,7 @@ import { createScheduledData } from '@paima/node-sdk/db';
 import type { WalletAddress } from '@paima/sdk/utils';
 import type { ConciseResult } from '@chess/utils';
 import type { UserStats } from '../types';
+import { PrecompileNames } from '@chess/precompiles';
 
 // Generate blank/empty user stats
 export function blankStats(wallet: string): SQLUpdate {
@@ -42,7 +43,11 @@ export function scheduleStatsUpdate(
   ratingChange: number,
   block_height: number
 ): SQLUpdate {
-  return createScheduledData(createStatsUpdateInput(wallet, result, ratingChange), block_height);
+  return createScheduledData(
+    createStatsUpdateInput(wallet, result, ratingChange),
+    block_height,
+    PrecompileNames.Default
+  );
 }
 
 // Create stats update input

--- a/chess/state-transition/src/stf/v1/persist/zombie.ts
+++ b/chess/state-transition/src/stf/v1/persist/zombie.ts
@@ -3,10 +3,11 @@ import { createScheduledData, deleteScheduledData } from '@paima/node-sdk/db';
 import { calculateBestMove } from './ai';
 import type { IGetLobbyByIdResult } from '@chess/db';
 import type { SubmittedMovesInput } from '../types';
+import { PrecompileNames } from '@chess/precompiles';
 
 // Schedule a zombie round to be executed in the future
 export function scheduleZombieRound(lobbyId: string, block_height: number): SQLUpdate {
-  return createScheduledData(createZombieInput(lobbyId), block_height);
+  return createScheduledData(createZombieInput(lobbyId), block_height, PrecompileNames.Default);
 }
 
 // Delete a scheduled zombie round to be executed in the future

--- a/chess/state-transition/tsconfig.json
+++ b/chess/state-transition/tsconfig.json
@@ -5,6 +5,24 @@
     "rootDir": "src",
     "outDir": "build"
   },
-  "include": ["src/**/*"],
-  "references": [{ "path": "../utils" }, { "path": "../game-logic" }, { "path": "../db" }]
+  "include": [
+    "src/**/*"
+  ],
+  "references": [
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../game-logic"
+    },
+    {
+      "path": "../db"
+    },
+    {
+      "path": "../events"
+    },
+    {
+      "path": "../precompiles"
+    }
+  ]
 }


### PR DESCRIPTION
This is not a functional change, just an example application of the current code in https://github.com/PaimaStudios/paima-engine/pull/409 . It's also possible it may not compile, since I'm using local dependencies.

I defined an overloaded event to just to show how it looks, but both events are emitted at the same time (which could be a valid use-case though)

The events table looks something like this:

![image](https://github.com/user-attachments/assets/480b0e4c-80eb-4ef6-be79-9630e63fbcd3)

The joined lobby event was never emitted so it's not there.

The registered_event table looks like this:

![image](https://github.com/user-attachments/assets/a8679fa5-d402-4650-aefc-d0fe783e415b)

The output of `mqtt subscribe -h 127.0.0.1 -p 8883 -q 2 -l ws -t '#' -v` looks something like this for example:

```
app/95a54b3250ababba95ca72d9c61a07554d8252746ad2ce711b44c0809adc75ac/user/0x82d9d608030496013587d9e0566509b2e6182afa/lobbyId/7ONFSpzOOwnO {"rounds":500}
app/b8c9872e0f8f4c6b9d9815fd4ff1f8746c6c4ca348911e7cda7fcc4771181ad6/user/0x82d9d608030496013587d9e0566509b2e6182afa/lobbyId/7ONFSpzOOwnO {"rounds":500,"isPractice":true}
node/block/1252 {}
node/block/1338 {}
app/365f0dd042b4225a85c20c6332be58dd5244de021b7778ef5d70d3056c9d5afa/winner/0x0 {}
node/block/1339 {}
```